### PR TITLE
Bugfix: Allow both Read and Write if both are present in the scope

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ exports.handler = function(event, context) {
     if (claims.scp.includes('api:read')) {
       policy.allowMethod(AuthPolicy.HttpVerb.GET, "*");
     }
-    else if (claims.scp.includes('api:write')) {
+    if (claims.scp.includes('api:write')) {
       policy.allowMethod(AuthPolicy.HttpVerb.POST, "*");
       policy.allowMethod(AuthPolicy.HttpVerb.PUT, "*");
       policy.allowMethod(AuthPolicy.HttpVerb.PATCH, "*");


### PR DESCRIPTION
Bug: if you provide both read and write scope `api:read api:write` only the `GET` method would be allowed.

Fix: Change the `else if` to an `if` when checking for `api:write` in the scp